### PR TITLE
Made table name on route case insensitive

### DIFF
--- a/src/authorize.js
+++ b/src/authorize.js
@@ -1,12 +1,13 @@
 ﻿// ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
+var utilities = require('./utilities');
 
 module.exports = function (configuration) {
     return function (req, res, next) {
-        var table = configuration.tables[req.params.tableName];
+        var table = utilities.caseInsensitiveProperty(configuration.tables, req.params.tableName);
 
-        if((specifiesAuthorization(table) || specifiesAuthorization(table.files)) && !authenticated())
+        if(table && (specifiesAuthorization(table) || specifiesAuthorization(table.files)) && !authenticated())
             res.status(401).send('You must be logged in to use this application');
         else
             next();

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,13 +1,14 @@
 // ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
-var permissions = require('./permissions');
+var permissions = require('./permissions'),
+    utilities = require('./utilities');
 
 module.exports = {
     construct: function(configuration, storage, operationName, defaultOperation) {
         return function (req, res, next) {
             var api = constructFilesApi(req.params.tableName, req.params.id),
-                table = configuration.tables[req.params.tableName];
+                table = utilities.caseInsensitiveProperty(configuration.tables, req.params.tableName);
 
             if (!table || !table.files) {
                 next();

--- a/src/router.js
+++ b/src/router.js
@@ -15,18 +15,18 @@ module.exports = function (configuration, storage, logger) {
         authorize = authorizeModule(configuration);
 
     router.post(route('StorageToken'), constructMiddleware('token', function (api, req) {
-        logger.silly(format('Generating SAS token for %s (%s)', req.params.tableName, req.params.id));
+        logger.silly(format('Generating SAS token for %s (%s)', req.params.tableName.toLowerCase(), req.params.id));
         // the .NET implementation returns a container level token by default, omit passing the name here to maintain the behavior
         return api.token(req.body && req.body.Permissions);
     }));
 
     router.get(route('MobileServiceFiles'), constructMiddleware('list', function (api, req) {
-        logger.silly(format('Listing files for %s (%s)', req.params.tableName, req.params.id));
+        logger.silly(format('Listing files for %s (%s)', req.params.tableName.toLowerCase(), req.params.id));
         return api.list();
     }));
 
     router.delete(route('MobileServiceFiles/:blobName'), constructMiddleware('delete', function (api, req) {
-        logger.silly(format('Deleting %s from %s (%s)', req.params.blobName, req.params.tableName, req.params.id));
+        logger.silly(format('Deleting %s from %s (%s)', req.params.blobName, req.params.tableName.toLowerCase(), req.params.id));
         return api.delete(req.params.blobName);
     }));
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,0 +1,16 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+module.exports = {
+    caseInsensitiveProperty: function (target, name) {
+        var result;
+        Object.keys(target).some(function (property) {
+            if(name.toLowerCase() === property.toLowerCase()) {
+                result = target[property];
+                return true;
+            }
+        });
+        return result;
+    }
+}

--- a/test/router.tests.js
+++ b/test/router.tests.js
@@ -70,6 +70,18 @@ describe('router', function () {
             });
     });
 
+    it('table name on route is case insensitive', function () {
+        var configuration = {
+                tableRootPath: '/tables',
+                tables: { todoitem: { files: true } }
+            },
+            app = getApp(configuration, getBlobStorageMock());
+
+        return supertest(app)
+            .post('/tables/TodoItem/1/StorageToken')
+            .expect(200);
+    });
+
     function getBlobStorageMock() {
         return {
             token: sinon.spy(),

--- a/test/utilities.tests.js
+++ b/test/utilities.tests.js
@@ -1,0 +1,25 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+var utilities = require('../src/utilities'),
+    expect = require('chai').expect;
+
+describe('utilities', function () {
+    describe('caseInsensitiveProperty', function () {
+        var target = {
+            'AbC': 'AbC',
+            'abC': 'abC',
+            'Undef': undefined,
+            'undef': 'undef'
+        };
+
+        it('finds first case insensitive match from object', function () {
+            expect(utilities.caseInsensitiveProperty(target, 'abc')).to.equal('AbC');
+            expect(utilities.caseInsensitiveProperty(target, 'undef')).to.be.undefined;
+        });
+
+        it('returns undefined if no match is found', function () {
+            expect(utilities.caseInsensitiveProperty(target, 'abcd')).to.be.undefined;
+        });
+    });
+});


### PR DESCRIPTION
So, this kind of sucks. Because we are mounting this middleware before tables are added to the configuration object (through add or import), we add a single generic route for each operation with table name as a route parameter - grabbing the table from configuration.tables is case sensitive, so we need this additional utility function.

I have considered in the past to call .toLowerCase() on the table name before adding it to configuration.tables when it is first added. This would also make req.azureMobile.tables(name) case insensitive, but it's a potentially breaking change.

@mamaso again for context